### PR TITLE
Fix headless screenshot rendering (partially)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,11 +65,12 @@ before_cache:
   # Travis can't cache files that are not readable by "others"
   - chmod -R a+r $HOME/.cargo
 
-# branches:
-#    only:
-#      # release tags
-#      - /^\d+\.\d+\.\d+.*$/
-#      - master
+branches:
+   only:
+     # release tags
+     - /^\d+\.\d+\.\d+.*$/
+     - master
+     - develop
 
 notifications:
   email:

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -17,8 +17,8 @@ impl Framebuffer {
             let mut texture_colorbuffer = 0;
             gl::GenTextures(1, &mut texture_colorbuffer);
             gl::BindTexture(gl::TEXTURE_2D, texture_colorbuffer);
-            gl::TexImage2D(gl::TEXTURE_2D, 0, gl::RGB as i32, width as i32, height as i32,
-                0, gl::RGB, gl::UNSIGNED_BYTE, ptr::null());
+            gl::TexImage2D(gl::TEXTURE_2D, 0, gl::RGBA as i32, width as i32, height as i32,
+                0, gl::RGBA, gl::UNSIGNED_BYTE, ptr::null());
             gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MIN_FILTER, gl::LINEAR as i32);
             gl::TexParameteri(gl::TEXTURE_2D, gl::TEXTURE_MAG_FILTER, gl::LINEAR as i32);
             gl::FramebufferTexture2D(gl::FRAMEBUFFER, gl::COLOR_ATTACHMENT0, gl::TEXTURE_2D, texture_colorbuffer, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,11 +91,7 @@ pub fn main() {
 
     let _ = TermLogger::init(log_level, LogConfig { time: None, target: None, ..LogConfig::default() });
 
-    // TODO!: headless rendering doesn't work (only clearcolor)
-    let mut viewer = GltfViewer::new(source, width, height,
-        false,
-        !args.is_present("screenshot")
-    );
+    let mut viewer = GltfViewer::new(source, width, height, args.is_present("screenshot"));
 
     if args.is_present("screenshot") {
         let filename = args.value_of("screenshot").unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,9 @@ pub fn main() {
             .default_value("1")
             .help("Saves N screenshots of size WxH, rotating evenly spaced around the object")
             .validator(|value| value.parse::<u32>().map(|_| ()).map_err(|err| err.to_string())))
+        .arg(Arg::with_name("headless")
+            .long("headless")
+            .help("Use real headless rendering for screenshots (Default is a hidden window) [EXPERIMENTAL]"))
         .get_matches();
     let source = args.value_of("FILE").unwrap();
     let width: u32 = args.value_of("WIDTH").unwrap().parse().unwrap();
@@ -91,7 +94,9 @@ pub fn main() {
 
     let _ = TermLogger::init(log_level, LogConfig { time: None, target: None, ..LogConfig::default() });
 
-    let mut viewer = GltfViewer::new(source, width, height, args.is_present("screenshot"));
+    let mut viewer = GltfViewer::new(source, width, height,
+        args.is_present("headless"),
+        !args.is_present("screenshot"));
 
     if args.is_present("screenshot") {
         let filename = args.value_of("screenshot").unwrap();
@@ -102,7 +107,7 @@ pub fn main() {
         if count > 1 {
             viewer.multiscreenshot(filename, width, height, count)
         } else {
-            viewer.screenshot(filename,width,height)
+            viewer.screenshot(filename, width, height)
         }
         return;
     }

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -137,7 +137,7 @@ impl Shader {
         let c_name = CString::new(name).unwrap();
         let loc = gl::GetUniformLocation(self.id, c_name.as_ptr());
         if loc == -1 {
-            info!("uniform '{}' unknown for shader {}", name, self.id);
+            trace!("uniform '{}' unknown for shader {}", name, self.id);
         }
         self.uniform_location_cache.insert(name, loc);
         loc

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,8 +1,11 @@
 #![macro_use]
 
+use std::ffi::CStr;
+use std::mem;
 use std::time::{Duration, Instant};
 
 use gl;
+use gl::types::GLubyte;
 
 pub fn elapsed(start_time: &Instant) -> String {
     let elapsed = start_time.elapsed();
@@ -102,4 +105,47 @@ macro_rules! gl_check_error {
     () => (
         gl_check_error(file!(), line!())
     )
+}
+
+/// Prints information about the current OpenGL context
+/// Based on glium's context::capabilities::get_capabilities
+pub unsafe fn print_context_info() {
+    debug!("Renderer     : {}", gl_string(gl::GetString(gl::RENDERER)));
+    debug!("Vendor       : {}", gl_string(gl::GetString(gl::VENDOR)));
+    debug!("Version      : {}", gl_string(gl::GetString(gl::VERSION)));
+    debug!("GLSL         : {}", gl_string(gl::GetString(gl::SHADING_LANGUAGE_VERSION)));
+
+    let mut val = mem::uninitialized();
+    gl::GetIntegerv(gl::CONTEXT_PROFILE_MASK, &mut val);
+    let val = val as gl::types::GLenum;
+    let profile = if (val & gl::CONTEXT_COMPATIBILITY_PROFILE_BIT) != 0 {
+        "Compatibility"
+    } else if (val & gl::CONTEXT_CORE_PROFILE_BIT) != 0 {
+        "Core"
+    } else {
+        "None"
+    };
+    debug!("Profile      : {}", profile);
+
+    let (debug, forward_compatible) = {
+        let mut val = mem::uninitialized();
+        gl::GetIntegerv(gl::CONTEXT_FLAGS, &mut val);
+        let val = val as gl::types::GLenum;
+        ((val & gl::CONTEXT_FLAG_DEBUG_BIT) != 0,
+         (val & gl::CONTEXT_FLAG_FORWARD_COMPATIBLE_BIT) != 0)
+    };
+    debug!("Context Flags: Debug: {}, Forward Compatible: {}", debug, forward_compatible);
+
+    let mut num_extensions = 0;
+    gl::GetIntegerv(gl::NUM_EXTENSIONS, &mut num_extensions);
+    let extensions: Vec<_> = (0 .. num_extensions).map(|num| {
+        gl_string(gl::GetStringi(gl::EXTENSIONS, num as gl::types::GLuint))
+    }).collect();
+    debug!("Extensions   : {}", extensions.join(", "))
+}
+
+pub unsafe fn gl_string(raw_string: *const GLubyte) -> String {
+    if raw_string.is_null() { return "(NULL)".into() }
+    String::from_utf8(CStr::from_ptr(raw_string as *const _).to_bytes().to_vec()).ok()
+                                .expect("gl_string: non-UTF8 string")
 }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -288,6 +288,7 @@ impl GltfViewer {
             gl::PixelStorei(gl::PACK_ALIGNMENT, 1);
             gl::ReadPixels(0, 0, width as i32, height as i32, gl::RGBA,
                 gl::UNSIGNED_BYTE, pixels.as_mut_ptr() as *mut c_void);
+            gl_check_error!();
         }
 
         let img = img.flipv();

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -61,8 +61,10 @@ pub struct GltfViewer {
     render_timer: FrameTimer,
 }
 
+/// Note about `headless` and `visible`: True headless rendering doesn't work on
+/// all operating systems, but an invisible window usually works
 impl GltfViewer {
-    pub fn new(source: &str, width: u32, height: u32, headless: bool) -> GltfViewer {
+    pub fn new(source: &str, width: u32, height: u32, headless: bool, visible: bool) -> GltfViewer {
         let gl_request = GlRequest::Specific(Api::OpenGl, (3, 3));
         let gl_profile = GlProfile::Core;
         let (events_loop, gl_window, width, height) =
@@ -88,7 +90,7 @@ impl GltfViewer {
                 let window = glutin::WindowBuilder::new()
                         .with_title("gltf-viewer")
                         .with_dimensions(width, height)
-                        .with_visibility(true);
+                        .with_visibility(visible);
 
                 let context = glutin::ContextBuilder::new()
                     .with_gl(gl_request)

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -30,7 +30,7 @@ use controls::CameraMovement::*;
 use framebuffer::Framebuffer;
 use render::*;
 use render::math::*;
-use utils::{print_elapsed, FrameTimer, gl_check_error};
+use utils::{print_elapsed, FrameTimer, gl_check_error, print_context_info};
 
 // TODO!: complete and pass through draw calls? or get rid of multiple shaders?
 // How about state ordering anyway?
@@ -128,6 +128,8 @@ impl GltfViewer {
         let last_y: f32 = height as f32 / 2.0;
 
         unsafe {
+            print_context_info();
+
             gl::ClearColor(0.0, 1.0, 0.0, 1.0); // green for debugging
             gl::Clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT);
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -120,6 +120,14 @@ impl GltfViewer {
             gl::ClearColor(0.0, 1.0, 0.0, 1.0); // green for debugging
             gl::Clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT);
 
+            if headless {
+                // transparent background for screenshots
+                gl::ClearColor(0.0, 0.0, 0.0, 0.0);
+            }
+            else {
+                gl::ClearColor(0.1, 0.2, 0.3, 1.0);
+            }
+
             gl::Enable(gl::DEPTH_TEST);
 
             // TODO: keyboard switch?
@@ -262,7 +270,6 @@ impl GltfViewer {
         unsafe {
             self.render_timer.start();
 
-            gl::ClearColor(0.1, 0.2, 0.3, 1.0);
             gl::Clear(gl::COLOR_BUFFER_BIT | gl::DEPTH_BUFFER_BIT);
 
             let cam_params = self.orbit_controls.camera_params();
@@ -275,11 +282,11 @@ impl GltfViewer {
     pub fn screenshot(&mut self, filename: &str, width: u32, height: u32) {
         self.draw();
 
-        let mut img = DynamicImage::new_rgb8(width, height);
+        let mut img = DynamicImage::new_rgba8(width, height);
         unsafe {
-            let pixels = img.as_mut_rgb8().unwrap();
+            let pixels = img.as_mut_rgba8().unwrap();
             gl::PixelStorei(gl::PACK_ALIGNMENT, 1);
-            gl::ReadPixels(0, 0, width as i32, height as i32, gl::RGB,
+            gl::ReadPixels(0, 0, width as i32, height as i32, gl::RGBA,
                 gl::UNSIGNED_BYTE, pixels.as_mut_ptr() as *mut c_void);
         }
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -9,9 +9,12 @@ use cgmath::{ Point3 };
 use gl;
 use glutin;
 use glutin::{
+    Api,
     MouseScrollDelta,
     MouseButton,
     GlContext,
+    GlRequest,
+    GlProfile,
     VirtualKeyCode,
     WindowEvent,
 };
@@ -60,9 +63,15 @@ pub struct GltfViewer {
 
 impl GltfViewer {
     pub fn new(source: &str, width: u32, height: u32, headless: bool) -> GltfViewer {
+        let gl_request = GlRequest::Specific(Api::OpenGl, (3, 3));
+        let gl_profile = GlProfile::Core;
         let (events_loop, gl_window, width, height) =
             if headless {
-                let headless_context = glutin::HeadlessRendererBuilder::new(width, height).build().unwrap();
+                let headless_context = glutin::HeadlessRendererBuilder::new(width, height)
+                    .with_gl(gl_request)
+                    .with_gl_profile(gl_profile)
+                    .build()
+                    .unwrap();
                 unsafe { headless_context.make_current().unwrap() }
                 gl::load_with(|symbol| headless_context.get_proc_address(symbol) as *const _);
                 let framebuffer = Framebuffer::new(width, height);
@@ -82,6 +91,8 @@ impl GltfViewer {
                         .with_visibility(true);
 
                 let context = glutin::ContextBuilder::new()
+                    .with_gl(gl_request)
+                    .with_gl_profile(gl_profile)
                     .with_vsync(true);
                 let gl_window = glutin::GlWindow::new(window, context, &events_loop).unwrap();
 

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -59,9 +59,7 @@ pub struct GltfViewer {
 }
 
 impl GltfViewer {
-    pub fn new(source: &str, width: u32, height: u32, headless: bool, visible: bool) -> GltfViewer {
-
-
+    pub fn new(source: &str, width: u32, height: u32, headless: bool) -> GltfViewer {
         let (events_loop, gl_window, width, height) =
             if headless {
                 let headless_context = glutin::HeadlessRendererBuilder::new(width, height).build().unwrap();
@@ -69,6 +67,7 @@ impl GltfViewer {
                 gl::load_with(|symbol| headless_context.get_proc_address(symbol) as *const _);
                 let framebuffer = Framebuffer::new(width, height);
                 framebuffer.bind();
+                unsafe { gl::Viewport(0, 0, width as i32, height as i32); }
 
                 (None, None, width, height) // TODO: real height (retina?)
             }
@@ -80,8 +79,7 @@ impl GltfViewer {
                 let window = glutin::WindowBuilder::new()
                         .with_title("gltf-viewer")
                         .with_dimensions(width, height)
-                        .with_visibility(visible);
-
+                        .with_visibility(true);
 
                 let context = glutin::ContextBuilder::new()
                     .with_vsync(true);
@@ -274,11 +272,9 @@ impl GltfViewer {
         }
     }
 
-    pub fn screenshot(&mut self, filename: &str, _width: u32, _height: u32) {
+    pub fn screenshot(&mut self, filename: &str, width: u32, height: u32) {
         self.draw();
 
-        // TODO!: headless case...
-        let (width, height) = self.gl_window.as_ref().unwrap().get_inner_size().unwrap();
         let mut img = DynamicImage::new_rgb8(width, height);
         unsafe {
             let pixels = img.as_mut_rgb8().unwrap();


### PR DESCRIPTION
Should solve #12.

Current state: Works fine on macOS, on Linux the resulting image is always black.

TODOs:
- ~~[ ] Fix Linux (black/transparent image - issue in `glutin`?)~~ (postponed)
- ~~[ ] Test on Windows~~ (postponed)
- [x] If not working on all platforms: add CLI switch to choose between 'real' headless and hidden window mode