### PR TITLE
Docker improvements (pull image, badge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,8 @@
 [![GitHub release](https://img.shields.io/github/release/bwasty/gltf-viewer.svg)](https://github.com/bwasty/gltf-viewer/releases/latest)
  [![](https://tokei.rs/b1/github/bwasty/gltf-viewer)](https://github.com/Aaronepower/tokei)
  [![Build Status](https://travis-ci.org/bwasty/gltf-viewer.svg?branch=master)](https://travis-ci.org/bwasty/gltf-viewer)
- [![Build status](https://ci.appveyor.com/api/projects/status/51ukh02thpb0r9cf/branch/master?svg=true)](https://ci.appveyor.com/project/bwasty/gltf-viewer/branch/master) <br>
- <!--
- [![Crates.io](https://img.shields.io/crates/d/gltf-viewer.svg)](https://crates.io/crates/gltf-viewer)
- [![Github All Releases](https://img.shields.io/github/downloads/bwasty/gltf-viewer/total.svg)](https://github.com/bwasty/gltf-viewer/releases)
--->
+ [![Build status](https://ci.appveyor.com/api/projects/status/51ukh02thpb0r9cf/branch/master?svg=true)](https://ci.appveyor.com/project/bwasty/gltf-viewer/branch/master)
+ [![Docker build status](https://img.shields.io/docker/build/bwasty/gltf-viewer.svg)](https://hub.docker.com/r/bwasty/gltf-viewer/tags/)
 
 Rust [glTF 2.0](https://github.com/KhronosGroup/glTF) viewer, written using the [gltf](https://github.com/gltf-rs/gltf) crate and plain OpenGL.
 
@@ -64,9 +61,14 @@ $ gltf-viewer Box.glb
 Proper headless screenshot generation with the `--headless` flag currently only works on macOS.
 To work around that, a Docker setup that uses `xvfb` is provided. Usage examples:
 ```
+# Build docker image and run it with the gltf mounted in a volume.
+# The image will be saved next to the gltf file.
 ./screenshot_docker.sh Box.glb
-./screenshot_docker.sh Box.glb -w 1920 -h 1080 --count 3 -vv
+./screenshot_docker.sh ../models/Box.gltf -w 1920 -h 1080 --count 3 -vv
+# Use pre-built docker image from Docker Hub
+DOCKER_IMAGE=bwasty/gltf-viewer ./screenshot_docker.sh Box.glb
 ```
+
 Alternatively, you can also install `xvfb` and use `./run_xvfb.sh` directly (Linux only).
 
 ## Goals

--- a/screenshot_docker.sh
+++ b/screenshot_docker.sh
@@ -4,6 +4,8 @@ set -eu
 if [[ ${#} -lt 1 ]]; then
     echo "Usage: ${0} <gltf-file-path> [<additional-arguments>]"
     echo "Example: ${0} ../gltf/Box.glb --count 3 --headless"
+    echo "You can pull a docker image instead of building locally by setting DOCKER_IMAGE."
+    echo "Example: DOCKER_IMAGE=bwasty/gltf-viewer:latest ${0} ../gltf/Box.glb"
     exit 1
 fi
 
@@ -13,10 +15,17 @@ gltf_file=$(basename "$gltf_path")
 model_name=${gltf_file%.*}
 output_file="$gltf_dir/$model_name.png"
 
-docker build -t gltf-viewer .
+if [[ ! -z "${DOCKER_IMAGE:-}" ]]; then
+    docker pull "$DOCKER_IMAGE"
+    image="$DOCKER_IMAGE"
+else
+    docker build -t gltf-viewer .
+    image=gltf-viewer
+fi
+
 rm "$output_file" || true
 docker run -t --rm -v "$(pwd)/$gltf_dir:/input" \
-    gltf-viewer "/input/$gltf_file" -s "/input/$model_name.png" "${@:2}"
+    $image "/input/$gltf_file" -s "/input/$model_name.png" "${@:2}"
 # uncomment to run bash interactively
-# docker run -it -v "$(pwd)/$gltf_dir:/input" --entrypoint bash gltf-viewer
+# docker run -it -v "$(pwd)/$gltf_dir:/input" --entrypoint bash $image
 [ -f "$HOME/.iterm2/imgcat" ] && "$HOME/.iterm2/imgcat" "$output_file"


### PR DESCRIPTION
With this, headless screenshot generation can be as simple as downloading `screenshot_docker.sh` and calling
```
DOCKER_IMAGE=bwasty/gltf-viewer ./screenshot_docker.sh <path-to-gltf>
```
(only docker is required)