### PR TITLE
Improve navigation & camera handling

### DIFF
--- a/src/controls.rs
+++ b/src/controls.rs
@@ -39,84 +39,6 @@ pub const ZOOM: f32 = 45.0;
 const MIN_ZOOM: f32 = 1.0;
 const MAZ_ZOOM: f32 = 170.0;
 
-/// NOTE: superceded by `OrbitControls`. Keeping the parts of it not (yet?) added there.
-pub struct CameraControls {
-    // Camera Attributes
-    pub position: Point3,
-
-    /// mutually exlusive: if center is set, it is used
-    pub front: Vector3,
-    pub center: Option<Point3>,
-
-    pub up: Vector3,
-    pub right: Vector3,
-    pub world_up: Vector3,
-    // Euler Angles
-    pub yaw: f32,
-    pub pitch: f32,
-    // Camera options
-    pub movement_speed: f32,
-    pub mouse_sensitivity: f32,
-
-    pub camera: Camera,
-
-    // pub moving_up: bool,
-    pub moving_left: bool,
-    // pub moving_down: bool,
-    pub moving_right: bool,
-    pub moving_forward: bool,
-    pub moving_backward: bool,
-}
-
-impl Default for CameraControls {
-    fn default() -> CameraControls {
-        let controls = CameraControls {
-            position: Point3::new(0.0, 0.0, 0.0),
-            front: vec3(0.0, 0.0, -1.0),
-            center: None,
-            up: Vector3::zero(), // initialized later
-            right: Vector3::zero(), // initialized later
-            world_up: Vector3::unit_y(),
-            yaw: YAW,
-            pitch: PITCH,
-            movement_speed: SPEED,
-            mouse_sensitivity: SENSITIVTY,
-
-            camera: Camera::default(),
-
-            // moving_up: false,
-            moving_left: false,
-            // moving_down: false,
-            moving_right: false,
-            moving_forward: false,
-            moving_backward: false,
-        };
-        // TODO!!: overriding default order...? -> NO!
-        // controls.update_camera_vectors();
-        controls
-    }
-}
-
-impl CameraControls {
-    pub fn set_camera(&mut self, camera: &Camera, transform: &Matrix4) {
-        // spec: If no transformation is specified, the location of the camera is at the origin.
-        let pos = transform * Vector4::zero();
-
-        // spec: ... the lens looks towards the local -Z axis ...
-        let look_at = transform * vec4(0.0, 0.0, -1.0, 0.0);
-
-        self.position = Point3::new(pos.x, pos.y, pos.z);
-        self.center = Some(Point3::new(look_at.x, look_at.y, look_at.z));
-
-        // TODO!!: handle better (camera zoom/fovy)
-        let mut camera = camera.clone();
-        camera.fovy = self.camera.fovy;
-        self.camera = camera;
-
-        // self.update_camera_vectors();
-    }
-}
-
 #[derive(Clone)]
 pub enum NavState {
     None,
@@ -394,5 +316,23 @@ impl OrbitControls {
             self.position += right * velocity;
             self.target += right * velocity;
         }
+    }
+
+    pub fn set_camera(&mut self, camera: &Camera, transform: &Matrix4) {
+        // spec: If no transformation is specified, the location of the camera is at the origin.
+        let pos = transform * Vector4::zero();
+
+        // spec: ... the lens looks towards the local -Z axis ...
+        let look_at = transform * vec4(0.0, 0.0, -1.0, 0.0);
+
+        self.position = Point3::new(pos.x, pos.y, pos.z);
+        self.target = Point3::new(look_at.x, look_at.y, look_at.z);
+
+        // TODO!!: handle better (camera zoom/fovy)
+        let mut camera = camera.clone();
+        camera.fovy = self.camera.fovy;
+        self.camera = camera;
+
+        self.camera.update_projection_matrix();
     }
 }

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -320,7 +320,7 @@ impl OrbitControls {
 
     pub fn set_camera(&mut self, camera: &Camera, transform: &Matrix4) {
         // spec: If no transformation is specified, the location of the camera is at the origin.
-        let pos = transform * Vector4::zero();
+        let pos = transform * vec4(0.0, 0.0, 0.0, 1.0);
 
         // spec: ... the lens looks towards the local -Z axis ...
         let look_at = transform * vec4(0.0, 0.0, -1.0, 0.0);
@@ -328,9 +328,9 @@ impl OrbitControls {
         self.position = Point3::new(pos.x, pos.y, pos.z);
         self.target = Point3::new(look_at.x, look_at.y, look_at.z);
 
-        // TODO!!: handle better (camera zoom/fovy)
+        // TODO!!: retaining current window aspect ratio for now... later maybe resize window accordingly?
         let mut camera = camera.clone();
-        camera.fovy = self.camera.fovy;
+        camera.update_aspect_ratio(self.camera.aspect_ratio());
         self.camera = camera;
 
         self.camera.update_projection_matrix();

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -1,6 +1,6 @@
 use std::f32::consts::PI;
 
-use cgmath::{vec3};
+use cgmath::{vec3, Deg};
 use cgmath::prelude::*;
 
 use num_traits::clamp;
@@ -282,6 +282,8 @@ impl OrbitControls {
         self.pan_offset = Vector3::zero();
 
         // NOTE: skip zoomChanged stuff
+
+        trace!("Position: {:?}\tTarget: {:?}\tfovy: {:?}", self.position, self.target, Deg(self.camera.fovy));
     }
 
     pub fn process_keyboard(&mut self, direction: CameraMovement, pressed: bool) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,8 @@ pub fn main() {
         .version(option_env!("VERSION").unwrap_or(crate_version!()))
         .setting(AppSettings::UnifiedHelpMessage)
         .setting(AppSettings::DeriveDisplayOrder)
+        .before_help("glTF 2.0 viewer\n\nNavigate with the mouse (left/right click + drag, mouse wheel) \
+                    or WASD/cursor keys.")
         .arg(Arg::with_name("FILE") // TODO!: re-add URL when fixed...
             .required(true)
             .takes_value(true)
@@ -90,10 +92,12 @@ pub fn main() {
         .arg(Arg::with_name("CAM-POS")
             .long("cam-pos")
             .takes_value(true)
+            .allow_hyphen_values(true)
             .help("Camera (aka eye) position override as comma-separated Vector3. Example: 1.2,3.4,5.6"))
         .arg(Arg::with_name("CAM-TARGET")
             .long("cam-target")
             .takes_value(true)
+            .allow_hyphen_values(true)
             .help("Camera target (aka center) override as comma-separated Vector3. Example: 1.2,3.4,5.6"))
         .arg(Arg::with_name("CAM-FOVY")
             .long("cam-fovy")

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,11 +79,18 @@ pub fn main() {
         .arg(Arg::with_name("headless")
             .long("headless")
             .help("Use real headless rendering for screenshots (Default is a hidden window) [EXPERIMENTAL]"))
+        .arg(Arg::with_name("CAM-INDEX")
+            .long("camera")
+            .takes_value(true)
+            .help("Use the glTF camera with the given index (starting at 0). \n\
+                Default: Determine 'nice' camera position based on the scene's bounding box.")
+            .validator(|value| value.parse::<u32>().map(|_| ()).map_err(|err| err.to_string())))
         .get_matches();
     let source = args.value_of("FILE").unwrap();
     let width: u32 = args.value_of("WIDTH").unwrap().parse().unwrap();
     let height: u32 = args.value_of("HEIGHT").unwrap().parse().unwrap();
     let count: u32 = args.value_of("COUNT").unwrap().parse().unwrap();
+    let camera_index: Option<u32> = args.value_of("CAM-INDEX").map(|n| n.parse().unwrap());
 
     let log_level = match args.occurrences_of("verbose") {
         0 => LevelFilter::Warn,
@@ -96,7 +103,8 @@ pub fn main() {
 
     let mut viewer = GltfViewer::new(source, width, height,
         args.is_present("headless"),
-        !args.is_present("screenshot"));
+        !args.is_present("screenshot"),
+        camera_index);
 
     if args.is_present("screenshot") {
         let filename = args.value_of("screenshot").unwrap();

--- a/src/render/camera.rs
+++ b/src/render/camera.rs
@@ -1,4 +1,4 @@
-use cgmath::{Deg, perspective};
+use cgmath::{Deg, Rad, perspective};
 
 use gltf;
 use gltf::camera::Projection;
@@ -15,7 +15,7 @@ pub struct Camera {
 
     // perspective camera
     // TODO!: setters that update...
-    pub fovy: f32,
+    pub fovy: f32, // degrees
     aspect_ratio: f32,
 
     // orthographic camera
@@ -53,9 +53,9 @@ impl Camera {
         };
         match g_camera.projection() {
             Projection::Perspective(persp) => {
-                // TODO!: ignoring aspect ratio for now as it would require window resizing...
+                // TODO!!: ignoring aspect ratio for now as it would require window resizing...
                 let _aspect = persp.aspect_ratio();
-                camera.fovy = persp.yfov();
+                camera.fovy = Deg::from(Rad(persp.yfov())).0;
                 camera.znear = persp.znear();
                 camera.zfar = persp.zfar();
             },
@@ -73,6 +73,10 @@ impl Camera {
     pub fn update_aspect_ratio(&mut self, aspect_ratio: f32) {
         self.aspect_ratio = aspect_ratio;
         self.update_projection_matrix();
+    }
+
+    pub fn aspect_ratio(&self) -> f32 {
+        self.aspect_ratio
     }
 
     pub fn update_projection_matrix(&mut self) {

--- a/src/render/math.rs
+++ b/src/render/math.rs
@@ -147,3 +147,14 @@ impl Spherical {
         vec3(x, y, z)
     }
 }
+
+use std::num::ParseFloatError;
+pub fn parse_vec3(s: &str) -> Result<Vector3, ParseFloatError> {
+    let coords: Vec<&str> = s.split(',').collect();
+    coords.len() != 3 && panic!("Failed to parse Vector3 ({})", s);
+    let x = coords[0].parse::<f32>()?;
+    let y = coords[1].parse::<f32>()?;
+    let z = coords[2].parse::<f32>()?;
+
+    Ok(vec3(x, y, z))
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -108,7 +108,7 @@ macro_rules! gl_check_error {
 }
 
 /// Prints information about the current OpenGL context
-/// Based on glium's context::capabilities::get_capabilities
+/// Based on glium's `context::capabilities::get_capabilities`
 pub unsafe fn print_context_info() {
     debug!("Renderer     : {}", gl_string(gl::GetString(gl::RENDERER)));
     debug!("Vendor       : {}", gl_string(gl::GetString(gl::VENDOR)));
@@ -146,6 +146,6 @@ pub unsafe fn print_context_info() {
 
 pub unsafe fn gl_string(raw_string: *const GLubyte) -> String {
     if raw_string.is_null() { return "(NULL)".into() }
-    String::from_utf8(CStr::from_ptr(raw_string as *const _).to_bytes().to_vec()).ok()
+    String::from_utf8(CStr::from_ptr(raw_string as *const _).to_bytes().to_vec())
                                 .expect("gl_string: non-UTF8 string")
 }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -414,10 +414,10 @@ fn process_input(input: glutin::KeyboardInput, controls: &mut OrbitControls) -> 
     if let Some(code) = input.virtual_keycode {
         match code {
             VirtualKeyCode::Escape if pressed => return false,
-            VirtualKeyCode::W => controls.process_keyboard(FORWARD, pressed),
-            VirtualKeyCode::S => controls.process_keyboard(BACKWARD, pressed),
-            VirtualKeyCode::A => controls.process_keyboard(LEFT, pressed),
-            VirtualKeyCode::D => controls.process_keyboard(RIGHT, pressed),
+            VirtualKeyCode::W | VirtualKeyCode::Up    => controls.process_keyboard(FORWARD, pressed),
+            VirtualKeyCode::S | VirtualKeyCode::Down  => controls.process_keyboard(BACKWARD, pressed),
+            VirtualKeyCode::A | VirtualKeyCode::Left  => controls.process_keyboard(LEFT, pressed),
+            VirtualKeyCode::D | VirtualKeyCode::Right => controls.process_keyboard(RIGHT, pressed),
             _ => ()
         }
     }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -267,14 +267,14 @@ impl GltfViewer {
             // events
             let keep_running = process_events(
                 &mut self.events_loop.as_mut().unwrap(), self.gl_window.as_mut().unwrap(),
-                &mut self.controls, &mut self.orbit_controls,
+                &mut self.orbit_controls,
                 &mut self.width, &mut self.height);
             if !keep_running {
                 unsafe { gl_check_error!(); } // final error check so errors don't go unnoticed
                 break
             }
 
-            self.controls.update(self.delta_time); // navigation
+            self.orbit_controls.frame_update(self.delta_time); // keyboard navigation
 
             self.draw();
 
@@ -337,8 +337,7 @@ impl GltfViewer {
 fn process_events(
     events_loop: &mut glutin::EventsLoop,
     gl_window: &glutin::GlWindow,
-    mut controls: &mut CameraControls,
-    orbit_controls: &mut OrbitControls,
+    mut orbit_controls: &mut OrbitControls,
     width: &mut u32,
     height: &mut u32) -> bool
 {
@@ -388,7 +387,7 @@ fn process_events(
                     orbit_controls.process_mouse_scroll(yoffset);
                 }
                 WindowEvent::KeyboardInput { input, .. } => {
-                    keep_running = process_input(input, &mut controls);
+                    keep_running = process_input(input, &mut orbit_controls);
                 }
                 _ => ()
             },
@@ -399,7 +398,7 @@ fn process_events(
     keep_running
 }
 
-fn process_input(input: glutin::KeyboardInput, camera: &mut CameraControls) -> bool {
+fn process_input(input: glutin::KeyboardInput, controls: &mut OrbitControls) -> bool {
     let pressed = match input.state {
         Pressed => true,
         Released => false
@@ -407,10 +406,10 @@ fn process_input(input: glutin::KeyboardInput, camera: &mut CameraControls) -> b
     if let Some(code) = input.virtual_keycode {
         match code {
             VirtualKeyCode::Escape if pressed => return false,
-            VirtualKeyCode::W => camera.process_keyboard(FORWARD, pressed),
-            VirtualKeyCode::S => camera.process_keyboard(BACKWARD, pressed),
-            VirtualKeyCode::A => camera.process_keyboard(LEFT, pressed),
-            VirtualKeyCode::D => camera.process_keyboard(RIGHT, pressed),
+            VirtualKeyCode::W => controls.process_keyboard(FORWARD, pressed),
+            VirtualKeyCode::S => controls.process_keyboard(BACKWARD, pressed),
+            VirtualKeyCode::A => controls.process_keyboard(LEFT, pressed),
+            VirtualKeyCode::D => controls.process_keyboard(RIGHT, pressed),
             _ => ()
         }
     }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -161,7 +161,7 @@ impl GltfViewer {
         };
         unsafe { gl_check_error!(); }
 
-        // TODO!!!: test more, create cli param / print num available cameras
+        // TODO!!!: create cli param / print num available cameras
         if !viewer.root.camera_nodes.is_empty() {
             info!("Using first gltf camera");
             // Take first camera node

--- a/tests/load_all_samples.sh
+++ b/tests/load_all_samples.sh
@@ -25,12 +25,12 @@ done
 # for file in $base_dir/**/glTF-Binary/*.glb; do
 #     model_name=$(basename "$file" .glb)
 #     echo "$model_name"
-# shellcheck disable=SC2086
+#     # shellcheck disable=SC2086
 #     target/"$mode"/gltf-viewer "$file" -s "$result_dir"/"$model_name"-Binary.png $rest_gltf_arguments
 # done
 
 # for file in $base_dir/**/glTF-Embedded/*.gltf; do
 #     model_name=$(basename "$file" .gltf)
-# shellcheck disable=SC2086
+#     # shellcheck disable=SC2086
 #     target/"$mode"/gltf-viewer "$file" -s "$result_dir"/"$model_name"-Embedded.png $rest_gltf_arguments
 # done

--- a/tests/load_all_samples.sh
+++ b/tests/load_all_samples.sh
@@ -4,9 +4,11 @@
 # Parameters:
 mode=${1:-release} # pass `debug` instead to test a debug build
 base_dir=${2:-../../glTF-Sample-Models/2.0}
+rest_gltf_arguments="${@:3}"
 
 # set -e
-mkdir -p target/screenshots
+result_dir=target/screenshots/$(date '+%Y-%m-%d_%H-%M-%S')
+mkdir -p "$result_dir"
 export CARGO_INCREMENTAL=1
 if [[ "$mode" == "release" ]]; then
     cargo build --release
@@ -16,17 +18,19 @@ fi
 
 for file in $base_dir/**/glTF/*.gltf; do
     model_name=$(basename "$file" .gltf)
-    echo "$model_name"
-    target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name".png --headless
+    # shellcheck disable=SC2086
+    target/"$mode"/gltf-viewer "$file" -s "$result_dir"/"$model_name".png $rest_gltf_arguments
 done
 
 # for file in $base_dir/**/glTF-Binary/*.glb; do
 #     model_name=$(basename "$file" .glb)
 #     echo "$model_name"
-#     target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name"-Binary.png --headless
+# shellcheck disable=SC2086
+#     target/"$mode"/gltf-viewer "$file" -s "$result_dir"/"$model_name"-Binary.png $rest_gltf_arguments
 # done
 
 # for file in $base_dir/**/glTF-Embedded/*.gltf; do
 #     model_name=$(basename "$file" .gltf)
-#     target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name"-Embedded.png --headless
+# shellcheck disable=SC2086
+#     target/"$mode"/gltf-viewer "$file" -s "$result_dir"/"$model_name"-Embedded.png $rest_gltf_arguments
 # done

--- a/tests/load_all_samples.sh
+++ b/tests/load_all_samples.sh
@@ -3,6 +3,7 @@
 # NOTE: should be called from crate root!
 # Parameters:
 mode=${1:-release} # pass `debug` instead to test a debug build
+base_dir={2:-../../glTF-Sample-Models/2.0}
 
 # set -e
 mkdir -p target/screenshots
@@ -13,18 +14,19 @@ else
     cargo build
 fi
 
-for file in ../gltf/glTF-Sample-Models/2.0/**/glTF/*.gltf; do
+for file in $base_dir/**/glTF/*.gltf; do
     model_name=$(basename "$file" .gltf)
-    target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name".png
+    echo "$model_name"
+    target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name".png --headless
 done
 
-# for file in ../gltf/glTF-Sample-Models/2.0/**/glTF-Binary/*.glb; do
+# for file in $base_dir/**/glTF-Binary/*.glb; do
 #     model_name=$(basename "$file" .glb)
 #     echo "$model_name"
-#     target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name"-Binary.png
+#     target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name"-Binary.png --headless
 # done
 
-# for file in ../gltf/glTF-Sample-Models/2.0/**/glTF-Embedded/*.gltf; do
+# for file in $base_dir/**/glTF-Embedded/*.gltf; do
 #     model_name=$(basename "$file" .gltf)
-#     target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name"-Embedded.png
+#     target/"$mode"/gltf-viewer "$file" -s target/screenshots/"$model_name"-Embedded.png --headless
 # done

--- a/tests/load_all_samples.sh
+++ b/tests/load_all_samples.sh
@@ -3,7 +3,7 @@
 # NOTE: should be called from crate root!
 # Parameters:
 mode=${1:-release} # pass `debug` instead to test a debug build
-base_dir={2:-../../glTF-Sample-Models/2.0}
+base_dir=${2:-../../glTF-Sample-Models/2.0}
 
 # set -e
 mkdir -p target/screenshots


### PR DESCRIPTION
* move WASD keyboard navigation to `OrbitControls` and remove the old controls completely
* several gltf camera related fixes: transform, fovy, aspect ratio
* add camera CLI parameters:
  - `--cam-index` (choose camera from gltf file)
  - `--cam-pos`
  - `--cam-target`
  - `--cam-fovy` (zoom)