### PR TITLE
exclude camera node bounds in scene bounds

### DIFF
--- a/src/render/node.rs
+++ b/src/render/node.rs
@@ -106,21 +106,11 @@ impl Node {
             self.bounds = mesh.bounds
                 .transform(&self.final_transform);
         }
-        else if self.camera.is_some() {
-            // Skip updating bounds for Cameras, since they don't have bounds.
-        }
-        else if self.children.is_empty() {
-            // Cameras (others?) have neither mesh nor children. Their position is the origin
-            // TODO!: are there other cases? Do bounds matter for cameras?
-            self.bounds = Aabb3::zero();
-            self.bounds = self.bounds.transform(&self.final_transform);
-        }
-        else {
-            for node_id in &self.children {
-                let node = root.unsafe_get_node_mut(*node_id);
-                node.update_bounds(root);
-                self.bounds = self.bounds.union(&node.bounds);
-            }
+
+        for node_id in &self.children {
+            let node = root.unsafe_get_node_mut(*node_id);
+            node.update_bounds(root);
+            self.bounds = self.bounds.union(&node.bounds);
         }
     }
 

--- a/src/render/node.rs
+++ b/src/render/node.rs
@@ -106,6 +106,9 @@ impl Node {
             self.bounds = mesh.bounds
                 .transform(&self.final_transform);
         }
+        else if self.camera.is_some() {
+            // Skip updating bounds for Cameras, since they don't have bounds.
+        }
         else if self.children.is_empty() {
             // Cameras (others?) have neither mesh nor children. Their position is the origin
             // TODO!: are there other cases? Do bounds matter for cameras?


### PR DESCRIPTION
Camera nodes should not have bounds set, as they are not actually part of the scene's bounds. This was causing screenshots of models with camera nodes to seem off-center.

closes #47 