### PR TITLE
add --straight flag to take model screenshots from head-on

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,7 @@ pub fn main() {
             .help("Use real headless rendering for screenshots (default is a hidden window) [EXPERIMENTAL - see README for details]"))
         .arg(Arg::with_name("straight")
             .long("straight")
-            .help("Position camera in front of model if not using default camera"))
+            .help("Position camera in front of model if using default camera (i.e. glTF doesn't contain a camera or `--cam-index -1` is passed."))
         .arg(Arg::with_name("scene")
             .long("scene")
             .default_value("0")

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,9 @@ pub fn main() {
         .arg(Arg::with_name("headless")
             .long("headless")
             .help("Use real headless rendering for screenshots (default is a hidden window) [EXPERIMENTAL - see README for details]"))
+        .arg(Arg::with_name("straight")
+            .long("straight")
+            .help("Position camera in front of model if not using default camera"))
         .arg(Arg::with_name("scene")
             .long("scene")
             .default_value("0")
@@ -130,6 +133,7 @@ pub fn main() {
         position: args.value_of("CAM-POS").map(|v| parse_vec3(v).unwrap()),
         target: args.value_of("CAM-TARGET").map(|v| parse_vec3(v).unwrap()),
         fovy: args.value_of("CAM-FOVY").map(|n| Deg(n.parse().unwrap())).unwrap(),
+        straight: args.is_present("straight"),
     };
 
     let log_level = match args.occurrences_of("verbose") {

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -45,6 +45,7 @@ pub struct CameraOptions {
     pub position: Option<Vector3>,
     pub target: Option<Vector3>,
     pub fovy: Deg<f32>,
+    pub straight: bool,
 }
 
 pub struct GltfViewer {
@@ -202,7 +203,7 @@ impl GltfViewer {
             }
         } else {
             info!("Determining camera view from bounding box");
-            viewer.set_camera_from_bounds(false);
+            viewer.set_camera_from_bounds(camera_options.straight);
 
             if let Some(p) = camera_options.position {
                 viewer.orbit_controls.position = Point3::from_vec(p)


### PR DESCRIPTION
This diff adds a `--straight` flag (flexible on the naming), which can toggle the `viewer.set_camera_from_bounds`' `straight` argument. I have some models which are meant to be looked at straight-on, and this would directly solve that issue.

A more generalized solution would be to be able to specify camera rotation angles around the bounding box, but I'm not sure how that would jive with the `count` flag.