### PR TITLE
Add alpha blending, draw modes and TEXCOORD_1 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.23
+FROM rust:1.28
 
 WORKDIR /usr/src/gltf-viewer
 COPY src src

--- a/src/controls.rs
+++ b/src/controls.rs
@@ -33,10 +33,7 @@ pub struct CameraParams {
 }
 
 // Default camera values
-const YAW: f32 = -90.0;
-const PITCH: f32 = 0.0;
 const SPEED: f32 = 2.5;
-const SENSITIVTY: f32 = 0.1;
 const ZOOM_SENSITIVITY: f32 = 0.1;
 pub const ZOOM: f32 = 45.0;
 const MIN_ZOOM: f32 = 1.0;
@@ -189,14 +186,14 @@ impl OrbitControls {
             Vector2::zero()
         };
 
-        self.pan(&pan_delta);
+        self.pan(pan_delta);
 
         self.pan_start = Some(self.pan_end);
 
         self.update();
     }
 
-    fn pan(&mut self, delta: &Vector2) {
+    fn pan(&mut self, delta: Vector2) {
         if self.camera.is_perspective() {
             let offset = self.position - self.target;
             let mut target_distance = offset.magnitude();

--- a/src/framebuffer.rs
+++ b/src/framebuffer.rs
@@ -44,6 +44,7 @@ impl Framebuffer {
         unsafe { gl::BindFramebuffer(gl::FRAMEBUFFER, self.id) }
     }
 
+    #[allow(dead_code)]
     pub fn unbind(&self) {
         unsafe { gl::BindFramebuffer(gl::FRAMEBUFFER, 0) }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
-#![allow(dead_code)]
+// #![allow(dead_code)]
 #![allow(unknown_lints)]
 // #![allow(unused_features)]
 // #![feature(test)]
+#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless, cyclomatic_complexity))]
+
 #[macro_use] extern crate clap;
 extern crate cgmath;
 use cgmath::Deg;

--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -123,9 +123,6 @@ fn load_texture(
     imp: &ImportData,
     base_path: &Path) -> Rc<Texture>
 {
-    // TODO!: handle tex coord set in shaders
-    assert_eq!(tex_coord, 0, "not yet implemented: tex coord set must be 0 (Material::from_gltf)");
-
     if let Some(tex) = root.textures.iter().find(|tex| (***tex).index == g_texture.index()) {
         return Rc::clone(tex)
     }

--- a/src/render/mesh.rs
+++ b/src/render/mesh.rs
@@ -38,7 +38,7 @@ impl Mesh {
 
         Mesh {
             index: g_mesh.index(),
-            primitives: primitives,
+            primitives,
             name: g_mesh.name().map(|s| s.into()),
             bounds,
         }

--- a/src/render/node.rs
+++ b/src/render/node.rs
@@ -74,6 +74,7 @@ impl Node {
     pub fn update_transform(&mut self, root: &mut Root, parent_transform: &Matrix4) {
         self.final_transform = *parent_transform;
 
+        // TODO: cache local tranform when adding animations?
         self.final_transform = self.final_transform *
             Matrix4::from_translation(self.translation) *
             Matrix4::from_nonuniform_scale(self.scale.x, self.scale.y, self.scale.z) *

--- a/src/render/primitive.rs
+++ b/src/render/primitive.rs
@@ -290,6 +290,7 @@ impl Primitive {
         if let Some(ref normal_texture) = mat.normal_texture {
             gl::ActiveTexture(gl::TEXTURE1);
             gl::BindTexture(gl::TEXTURE_2D, normal_texture.id);
+            shader.set_float(uniforms.u_NormalScale, mat.normal_scale.unwrap_or(1.0));
         }
         if let Some(ref emissive_texture) = mat.emissive_texture {
             gl::ActiveTexture(gl::TEXTURE2);

--- a/src/render/primitive.rs
+++ b/src/render/primitive.rs
@@ -286,22 +286,25 @@ impl Primitive {
         if let Some(ref base_color_texture) = mat.base_color_texture {
             gl::ActiveTexture(gl::TEXTURE0);
             gl::BindTexture(gl::TEXTURE_2D, base_color_texture.id);
+            shader.set_int(uniforms.u_BaseColorTexCoord, base_color_texture.tex_coord as i32);
         }
         if let Some(ref normal_texture) = mat.normal_texture {
             gl::ActiveTexture(gl::TEXTURE1);
             gl::BindTexture(gl::TEXTURE_2D, normal_texture.id);
+            shader.set_int(uniforms.u_NormalTexCoord, normal_texture.tex_coord as i32);
             shader.set_float(uniforms.u_NormalScale, mat.normal_scale.unwrap_or(1.0));
         }
         if let Some(ref emissive_texture) = mat.emissive_texture {
             gl::ActiveTexture(gl::TEXTURE2);
             gl::BindTexture(gl::TEXTURE_2D, emissive_texture.id);
-
+            shader.set_int(uniforms.u_EmissiveTexCoord, emissive_texture.tex_coord as i32);
             shader.set_vector3(uniforms.u_EmissiveFactor, &mat.emissive_factor);
         }
 
         if let Some(ref mr_texture) = mat.metallic_roughness_texture {
             gl::ActiveTexture(gl::TEXTURE3);
             gl::BindTexture(gl::TEXTURE_2D, mr_texture.id);
+            shader.set_int(uniforms.u_MetallicRoughnessTexCoord, mr_texture.tex_coord as i32);
         }
         shader.set_vec2(uniforms.u_MetallicRoughnessValues,
             mat.metallic_factor, mat.roughness_factor);
@@ -309,7 +312,7 @@ impl Primitive {
         if let Some(ref occlusion_texture) = mat.occlusion_texture {
             gl::ActiveTexture(gl::TEXTURE4);
             gl::BindTexture(gl::TEXTURE_2D, occlusion_texture.id);
-
+            shader.set_int(uniforms.u_OcclusionTexCoord, occlusion_texture.tex_coord as i32);
             shader.set_float(uniforms.u_OcclusionStrength, mat.occlusion_strength);
         }
     }

--- a/src/render/primitive.rs
+++ b/src/render/primitive.rs
@@ -101,9 +101,10 @@ impl Primitive {
         let positions = {
             let iter = reader
                 .read_positions()
-                .expect(&format!(
-                    "primitives must have the POSITION attribute (mesh: {}, primitive: {})",
-                    mesh_index, primitive_index));
+                .unwrap_or_else(||
+                    panic!("primitives must have the POSITION attribute (mesh: {}, primitive: {})",
+                        mesh_index, primitive_index)
+                );
             iter.collect::<Vec<_>>()
         };
 

--- a/src/render/scene.rs
+++ b/src/render/scene.rs
@@ -46,6 +46,8 @@ impl Scene {
 
     // TODO: flatten draw call hierarchy (global Vec<Primitive>?)
     pub fn draw(&mut self, root: &mut Root, cam_params: &CameraParams) {
+        // TODO!: for correct alpha blending, sort by material alpha mode and
+        // render opaque objects first.
         for node_id in &self.nodes {
             let node = root.unsafe_get_node_mut(*node_id);
             node.draw(root, cam_params);

--- a/src/render/texture.rs
+++ b/src/render/texture.rs
@@ -73,29 +73,27 @@ impl Texture {
                             g_img.index(), mime_type)),
                     }
                 }
+                else if let Some(mime_type) = mime_type {
+                    let path = base_path.parent().unwrap_or_else(|| Path::new("./")).join(uri);
+                    let file = fs::File::open(path).unwrap();
+                    let reader = io::BufReader::new(file);
+                    match mime_type {
+                        "image/jpeg" => image::load(reader, JPEG),
+                        "image/png" => image::load(reader, PNG),
+                        _ => panic!(format!("unsupported image type (image: {}, mime_type: {})",
+                            g_img.index(), mime_type)),
+                    }
+                }
                 else {
-                    if let Some(mime_type) = mime_type {
-                        let path = base_path.parent().unwrap_or_else(|| Path::new("./")).join(uri);
-                        let file = fs::File::open(path).unwrap();
-                        let reader = io::BufReader::new(file);
-                        match mime_type {
-                            "image/jpeg" => image::load(reader, JPEG),
-                            "image/png" => image::load(reader, PNG),
-                            _ => panic!(format!("unsupported image type (image: {}, mime_type: {})",
-                                g_img.index(), mime_type)),
-                        }
-                    }
-                    else {
-                        let path = base_path.parent().unwrap_or_else(||Path::new("./")).join(uri);
-                        image::open(path)
-                    }
+                    let path = base_path.parent().unwrap_or_else(||Path::new("./")).join(uri);
+                    image::open(path)
                 }
             }
         };
 
         // TODO: handle I/O problems
         let dyn_img = img.expect("Image loading failed.");
-        
+
         let format = match dyn_img {
             ImageLuma8(_) => gl::RED,
             ImageLumaA8(_) => gl::RG,
@@ -134,7 +132,7 @@ impl Texture {
             index: g_texture.index(),
             name: g_texture.name().map(|s| s.into()),
             id: texture_id,
-            tex_coord: tex_coord,
+            tex_coord,
         }
     }
 

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -246,6 +246,9 @@ pub struct PbrUniformLocations {
     pub u_OcclusionTexCoord: i32,
     pub u_OcclusionStrength: i32,
 
+    pub u_AlphaBlend: i32,
+    pub u_AlphaCutoff: i32,
+
     // TODO!: use/remove debugging uniforms
     // debugging flags used for shader output of intermediate PBR variables
     pub u_ScaleDiffBaseMR: i32,
@@ -307,6 +310,9 @@ impl PbrShader {
                 u_OcclusionSampler: shader.uniform_location("u_OcclusionSampler"),
                 u_OcclusionTexCoord: shader.uniform_location("u_OcclusionTexCoord"),
                 u_OcclusionStrength: shader.uniform_location("u_OcclusionStrength"),
+
+                u_AlphaBlend: shader.uniform_location("u_AlphaBlend"),
+                u_AlphaCutoff: shader.uniform_location("u_AlphaCutoff"),
 
                 u_ScaleDiffBaseMR: shader.uniform_location("u_ScaleDiffBaseMR"),
                 u_ScaleFGDSpec: shader.uniform_location("u_ScaleFGDSpec"),

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -227,18 +227,23 @@ pub struct PbrUniformLocations {
     ///
 
     pub u_BaseColorSampler: i32,
+    pub u_BaseColorTexCoord: i32,
     pub u_BaseColorFactor: i32,
 
     pub u_NormalSampler: i32,
+    pub u_NormalTexCoord: i32,
     pub u_NormalScale: i32,
 
     pub u_EmissiveSampler: i32,
+    pub u_EmissiveTexCoord: i32,
     pub u_EmissiveFactor: i32,
 
     pub u_MetallicRoughnessSampler: i32,
+    pub u_MetallicRoughnessTexCoord: i32,
     pub u_MetallicRoughnessValues: i32,
 
     pub u_OcclusionSampler: i32,
+    pub u_OcclusionTexCoord: i32,
     pub u_OcclusionStrength: i32,
 
     // TODO!: use/remove debugging uniforms
@@ -284,18 +289,23 @@ impl PbrShader {
                 u_brdfLUT: shader.uniform_location("u_brdfLUT"),
 
                 u_BaseColorSampler: shader.uniform_location("u_BaseColorSampler"),
+                u_BaseColorTexCoord: shader.uniform_location("u_BaseColorTexCoord"),
                 u_BaseColorFactor: shader.uniform_location("u_BaseColorFactor"),
 
                 u_NormalSampler: shader.uniform_location("u_NormalSampler"),
+                u_NormalTexCoord: shader.uniform_location("u_NormalTexCoord"),
                 u_NormalScale: shader.uniform_location("u_NormalScale"),
 
                 u_EmissiveSampler: shader.uniform_location("u_EmissiveSampler"),
+                u_EmissiveTexCoord: shader.uniform_location("u_EmissiveTexCoord"),
                 u_EmissiveFactor: shader.uniform_location("u_EmissiveFactor"),
 
                 u_MetallicRoughnessSampler: shader.uniform_location("u_MetallicRoughnessSampler"),
+                u_MetallicRoughnessTexCoord: shader.uniform_location("u_MetallicRoughnessTexCoord"),
                 u_MetallicRoughnessValues: shader.uniform_location("u_MetallicRoughnessValues"),
 
                 u_OcclusionSampler: shader.uniform_location("u_OcclusionSampler"),
+                u_OcclusionTexCoord: shader.uniform_location("u_OcclusionTexCoord"),
                 u_OcclusionStrength: shader.uniform_location("u_OcclusionStrength"),
 
                 u_ScaleDiffBaseMR: shader.uniform_location("u_ScaleDiffBaseMR"),

--- a/src/shader.rs
+++ b/src/shader.rs
@@ -17,10 +17,11 @@ pub struct Shader {
 }
 
 impl Shader {
+    #[allow(dead_code)]
     pub fn new(vertex_path: &str, fragment_path: &str, defines: &[String]) -> Shader {
         // 1. retrieve the vertex/fragment source code from filesystem
-        let mut v_shader_file = File::open(vertex_path).expect(&format!("Failed to open {}", vertex_path));
-        let mut f_shader_file = File::open(fragment_path).expect(&format!("Failed to open {}", fragment_path));
+        let mut v_shader_file = File::open(vertex_path).unwrap_or_else(|_| panic!("Failed to open {}", vertex_path));
+        let mut f_shader_file = File::open(fragment_path).unwrap_or_else(|_| panic!("Failed to open {}", fragment_path));
         let mut vertex_code = String::new();
         let mut fragment_code = String::new();
         v_shader_file
@@ -96,6 +97,7 @@ impl Shader {
 
     /// utility uniform functions
     /// ------------------------------------------------------------------------
+    #[allow(dead_code)]
     pub unsafe fn set_bool(&self, location: i32, value: bool) {
         gl::Uniform1i(location, value as i32);
     }
@@ -196,7 +198,7 @@ bitflags! {
 }
 
 impl ShaderFlags {
-    pub fn as_strings(&self) -> Vec<String> {
+    pub fn as_strings(self) -> Vec<String> {
         (0..15)
             .map(|i| 1u16 << i)
             .filter(|i| self.bits & i != 0)

--- a/src/shaders/pbr-frag.glsl
+++ b/src/shaders/pbr-frag.glsl
@@ -129,7 +129,8 @@ vec3 getNormal()
     vec3 n = texture(u_NormalSampler, v_UV).rgb;
     n = normalize(tbn * ((2.0 * n - 1.0) * vec3(u_NormalScale, u_NormalScale, 1.0)));
 #else
-    vec3 n = tbn[2].xyz;
+    // The tbn matrix is linearly interpolated, so we need to re-normalize
+    vec3 n = normalize(tbn[2].xyz);
 #endif
 
     // reverse backface normals
@@ -258,7 +259,7 @@ void main()
     vec3 reflection = -normalize(reflect(v, n));
 
     float NdotL = clamp(dot(n, l), 0.001, 1.0);
-    float NdotV = abs(dot(n, v)) + 0.001;
+    float NdotV = clamp(abs(dot(n, v)), 0.001, 1.0);
     float NdotH = clamp(dot(n, h), 0.0, 1.0);
     float LdotH = clamp(dot(l, h), 0.0, 1.0);
     float VdotH = clamp(dot(v, h), 0.0, 1.0);

--- a/src/shaders/pbr-vert.glsl
+++ b/src/shaders/pbr-vert.glsl
@@ -40,6 +40,7 @@ void main()
 
   #ifdef HAS_NORMALS
   #ifdef HAS_TANGENTS
+  // TODO!: the reference shader was updated to use the normal matrix here
   vec3 normalW = normalize(vec3(u_ModelMatrix * vec4(a_Normal.xyz, 0.0)));
   vec3 tangentW = normalize(vec3(u_ModelMatrix * vec4(a_Tangent.xyz, 0.0)));
   vec3 bitangentW = cross(normalW, tangentW) * a_Tangent.w;

--- a/src/shaders/pbr-vert.glsl
+++ b/src/shaders/pbr-vert.glsl
@@ -10,7 +10,8 @@ layout (location = 1) in vec4 a_Normal;
 layout (location = 2) in vec4 a_Tangent;
 #endif
 #ifdef HAS_UV
-layout (location = 3) in vec2 a_UV; // TEXCOORD_0
+layout (location = 3) in vec2 a_UV_0; // TEXCOORD_0
+layout (location = 4) in vec2 a_UV_1; // TEXCOORD_1
 #endif
 // TODO!: tex_coord_1, joints_0, weights_0
 #ifdef HAS_COLORS
@@ -21,7 +22,7 @@ uniform mat4 u_MVPMatrix;
 uniform mat4 u_ModelMatrix;
 
 out vec3 v_Position;
-out vec2 v_UV;
+out vec2 v_UV[2];
 out vec4 v_Color;
 
 #ifdef HAS_NORMALS
@@ -51,9 +52,11 @@ void main()
   #endif
 
   #ifdef HAS_UV
-  v_UV = a_UV;
+  v_UV[0] = a_UV_0;
+  v_UV[1] = a_UV_1;
   #else
-  v_UV = vec2(0.,0.);
+  v_UV[0] = vec2(0.,0.);
+  v_UV[1] = vec2(0.,0.);
   #endif
 
   #ifdef HAS_COLORS

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use gl;
 use gl::types::GLubyte;
 
-pub fn elapsed(start_time: &Instant) -> String {
+pub fn elapsed(start_time: Instant) -> String {
     let elapsed = start_time.elapsed();
     format_duration(elapsed)
 }
@@ -33,7 +33,7 @@ fn format_duration(duration: Duration) -> String {
     }
 }
 
-pub fn print_elapsed(message: &str, start_time: &Instant) {
+pub fn print_elapsed(message: &str, start_time: Instant) {
     info!("{:<25}{}", message, elapsed(start_time));
 }
 
@@ -50,7 +50,7 @@ impl FrameTimer {
     pub fn new(message: &str, averaging_window: usize) -> FrameTimer {
         FrameTimer {
             message: message.to_owned(),
-            averaging_window: averaging_window,
+            averaging_window,
             current_frame_start: Instant::now(),
             frame_times: Vec::with_capacity(averaging_window),
         }

--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -40,6 +40,7 @@ use utils::{print_elapsed, FrameTimer, gl_check_error, print_context_info};
 //     back_face_culling_enabled: bool
 // }
 
+#[derive(Copy, Clone)]
 pub struct CameraOptions {
     pub index: i32,
     pub position: Option<Vector3>,
@@ -53,9 +54,6 @@ pub struct GltfViewer {
     dpi_factor: f64,
 
     orbit_controls: OrbitControls,
-    first_mouse: bool,
-    last_x: f32,
-    last_y: f32,
     events_loop: Option<glutin::EventsLoop>,
     gl_window: Option<glutin::GlWindow>,
 
@@ -134,10 +132,6 @@ impl GltfViewer {
         orbit_controls.camera.fovy = camera_options.fovy;
         orbit_controls.camera.update_aspect_ratio(inner_size.width as f32 / inner_size.height as f32); // updates projection matrix
 
-        let first_mouse = true;
-        let last_x: f32 = inner_size.width as f32 / 2.0;
-        let last_y: f32 = inner_size.height as f32 / 2.0;
-
         unsafe {
             print_context_info();
 
@@ -165,7 +159,6 @@ impl GltfViewer {
             dpi_factor,
 
             orbit_controls,
-            first_mouse, last_x, last_y,
 
             events_loop,
             gl_window,
@@ -235,7 +228,7 @@ impl GltfViewer {
         };
         let imp = ImportData { doc, buffers, images };
 
-        print_elapsed("Imported glTF in ", &start_time);
+        print_elapsed("Imported glTF in ", start_time);
         start_time = Instant::now();
 
         // load first scene
@@ -247,7 +240,7 @@ impl GltfViewer {
         let mut root = Root::from_gltf(&imp, base_path);
         let scene = Scene::from_gltf(&imp.doc.scenes().nth(scene_index).unwrap(), &mut root);
         print_elapsed(&format!("Loaded scene with {} nodes, {} meshes in ",
-                imp.doc.nodes().count(), imp.doc.meshes().len()), &start_time);
+                imp.doc.nodes().count(), imp.doc.meshes().len()), start_time);
 
         (root, scene)
     }


### PR DESCRIPTION
Also: various small fixes and some cleanup.

NOTE: alpha blending doesn't work perfectly since there's no sorting implemented (but pixels with zero alpha value are discarded), see also implementation note [here](https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#alpha-coverage).