### PR TITLE
Fixed ambiguous import compilation error.

### DIFF
--- a/src/render/material.rs
+++ b/src/render/material.rs
@@ -4,7 +4,8 @@ use std::path::Path;
 use gltf;
 
 use render::math::*;
-use render::{ Root, Texture };
+use render::{ Root };
+use render::texture::Texture;
 use shader::*;
 use importdata::ImportData;
 

--- a/src/render/root.rs
+++ b/src/render/root.rs
@@ -5,7 +5,8 @@ use std::collections::HashMap;
 use std::path::Path;
 
 use shader::*;
-use render::{Mesh, Node, Texture, Material};
+use render::{Mesh, Node, Material};
+use render::texture::Texture;
 use importdata::ImportData;
 
 #[derive(Default)]


### PR DESCRIPTION
This fixed the build on Rust 1.31.0 where it was not building due to the following error:

```
cargo build
   Compiling gltf-viewer v0.4.1-alpha.0 (gltf-viewer)
error[E0659]: `Texture` is ambiguous (glob import vs glob import in the same module)
 --> src\render\root.rs:8:26
  |
8 | use render::{Mesh, Node, Texture, Material};
  |                          ^^^^^^^ ambiguous name
  |
note: `Texture` could refer to the struct imported here
 --> src\render\mod.rs:18:9
  |
18| pub use self::texture::*;
  |         ^^^^^^^^^^^^^^^^
  = help: consider adding an explicit import of `Texture` to disambiguate
note: `Texture` could also refer to the struct imported here
 --> src\render\mod.rs:13:9
  |
13| pub use self::primitive::*;
  |         ^^^^^^^^^^^^^^^^^^
  = help: consider adding an explicit import of `Texture` to disambiguate

error[E0659]: `Texture` is ambiguous (glob import vs glob import in the same module)
 --> src\render\material.rs:7:21
  |
7 | use render::{ Root, Texture };
  |                     ^^^^^^^ ambiguous name
  |
note: `Texture` could refer to the struct imported here
 --> src\render\mod.rs:18:9
  |
18| pub use self::texture::*;
  |         ^^^^^^^^^^^^^^^^
  = help: consider adding an explicit import of `Texture` to disambiguate
note: `Texture` could also refer to the struct imported here
 --> src\render\mod.rs:13:9
  |
13| pub use self::primitive::*;
  |         ^^^^^^^^^^^^^^^^^^
  = help: consider adding an explicit import of `Texture` to disambiguate

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0659`.
error: Could not compile `gltf-viewer`.

To learn more, run the command again with --verbose.

```