### PR TITLE
Use an equal-width suffix number with left-padded zeroes for screenshot filenames

### DIFF
--- a/src/viewer.rs
+++ b/src/viewer.rs
@@ -339,11 +339,12 @@ impl GltfViewer {
         let min_angle : f32 = 0.0 ;
         let max_angle : f32 =  2.0 * PI ;
         let increment_angle : f32 = ((max_angle - min_angle)/(count as f32)) as f32;
+        let suffix_length = count.to_string().len();
         for i in 1..=count {
             self.orbit_controls.rotate_object(increment_angle);
             let dot = filename.rfind('.').unwrap_or_else(|| filename.len());
             let mut actual_name = filename.to_string();
-            actual_name.insert_str(dot, &format!("_{}", i));
+            actual_name.insert_str(dot, &format!("_{:0suffix_length$}", i, suffix_length = suffix_length));
             self.screenshot(&actual_name[..]);
         }
     }


### PR DESCRIPTION
When generating multiple screenshots, the output images' filenames have a number suffix appended before the filename extension.

However, the previous logic generated suffixes that would yield an incorrect sequence when ordering the files by filename.

For instance, generating 15 screenshots creates 15 files, with names `filename_1.png`, `filename_2.png`...`filename_10.png`...`filename_14.png`. The issue lies when ordering these files by filename: ascending order yields the incorrect order `filename_1.png`, `filename_10.png`, `filename_11.png`...`filename_2.png`.

**This PR generates left-zero-padded, equal-width suffixes for the screenshot filenames**, so that ordering the filenames yields correct sequences. For instance, instead of `filename_1.png` the application yields `filename_01.png`.

The width of the suffix is dynamic, based on the length of the number provided as the `count` parameter.